### PR TITLE
Add Inverted Eastron kWh meter

### DIFF
--- a/SmartEVSE-3/include/evse.h
+++ b/SmartEVSE-3/include/evse.h
@@ -299,10 +299,11 @@
 #define EM_PHOENIX_CONTACT 2
 #define EM_FINDER 3
 #define EM_EASTRON 4
-#define EM_ABB 5
-#define EM_SOLAREDGE 6
-#define EM_WAGO 7
-#define EM_CUSTOM 8
+#define EM_EASTRON_INV 5
+#define EM_ABB 6
+#define EM_SOLAREDGE 7
+#define EM_WAGO 8
+#define EM_CUSTOM 9
 
 #define ENDIANESS_LBF_LWF 0
 #define ENDIANESS_LBF_HWF 1

--- a/SmartEVSE-3/src/evse.cpp
+++ b/SmartEVSE-3/src/evse.cpp
@@ -217,7 +217,8 @@ struct EMstruct EMConfig[EM_CUSTOM + 1] = {
     {"Phoenix C", ENDIANESS_HBF_LWF, 4, MB_DATATYPE_INT32,      0x0, 1,    0xC, 3,   0x28, 1,   0x3E, 1}, // PHOENIX CONTACT EEM-350-D-MCB (0,1V / mA / 0,1W / 0,1kWh) max read count 11
     {"Finder",    ENDIANESS_HBF_HWF, 4, MB_DATATYPE_FLOAT32, 0x1000, 0, 0x100E, 0, 0x1026, 0, 0x1106, 3}, // Finder 7E.78.8.400.0212 (V / A / W / Wh) max read count 127
     {"Eastron",   ENDIANESS_HBF_HWF, 4, MB_DATATYPE_FLOAT32,    0x0, 0,    0x6, 0,   0x34, 0,  0x156, 0}, // Eastron SDM630 (V / A / W / kWh) max read count 80
-    {"ABB",       ENDIANESS_HBF_HWF, 3, MB_DATATYPE_INT32,   0x5B00, 1, 0x5B0C, 2, 0x5B14, 2, 0x5002, 2}, // ABB B23 212-100 (0.1V / 0.01A / 0.01W / 0.01kWh) RS485 wiring reversed / max read count 125
+    {"InvEastrn", ENDIANESS_HBF_HWF, 4, MB_DATATYPE_FLOAT32,    0x0, 0,    0x6, 0,   0x34, 0,  0x156, 0}, // Since Eastron SDM series are bidirectional, sometimes they are connected upsidedown, so positive current becomes negative etc.; Eastron SDM630 (V / A / W / kWh) max read count 80
+		{"ABB",       ENDIANESS_HBF_HWF, 3, MB_DATATYPE_INT32,   0x5B00, 1, 0x5B0C, 2, 0x5B14, 2, 0x5002, 2}, // ABB B23 212-100 (0.1V / 0.01A / 0.01W / 0.01kWh) RS485 wiring reversed / max read count 125
     {"SolarEdge", ENDIANESS_HBF_HWF, 3, MB_DATATYPE_INT16,    40196, 0,  40191, 0,  40083, 0,  40226, 3}, // SolarEdge SunSpec (0.01V (16bit) / 0.1A (16bit) / 1W  (16bit) / 1 Wh (32bit))
     {"WAGO",      ENDIANESS_HBF_HWF, 3, MB_DATATYPE_FLOAT32, 0x5002, 0, 0x500C, 0, 0x5012, 3, 0x6000, 0}, // WAGO 879-30x0 (V / A / kW / kWh)
     {"Custom",    ENDIANESS_LBF_LWF, 4, MB_DATATYPE_INT32,        0, 0,      0, 0,      0, 0,      0, 0}  // Last entry!

--- a/SmartEVSE-3/src/modbus.cpp
+++ b/SmartEVSE-3/src/modbus.cpp
@@ -522,6 +522,7 @@ void requestCurrentMeasurement(uint8_t Meter, uint8_t Address) {
             ModbusReadInputRequest(Address, 4, 0, 20);
             break;
         case EM_EASTRON:
+        case EM_EASTRON_INV:
             // Phase 1-3 current: Register 0x06 - 0x0B (unsigned)
             // Phase 1-3 power:   Register 0x0C - 0x11 (signed)
             ModbusReadInputRequest(Address, 4, 0x06, 12);
@@ -624,6 +625,11 @@ uint8_t receiveCurrentMeasurement(uint8_t *buf, uint8_t Meter, signed int *var) 
         case EM_EASTRON:
             for (x = 0; x < 3; x++) {
                 if (receiveMeasurement(buf, x + 3u, EMConfig[Meter].Endianness, EMConfig[Meter].DataType, EMConfig[Meter].PDivisor) < 0) var[x] = -var[x];
+            }
+            break;
+        case EM_EASTRON_INV:
+            for (x = 0; x < 3; x++) {
+                if (receiveMeasurement(buf, x + 3u, EMConfig[Meter].Endianness, EMConfig[Meter].DataType, EMConfig[Meter].PDivisor) > 0) var[x] = -var[x];
             }
             break;
         case EM_ABB:


### PR DESCRIPTION
The Eastron SDM series kWh meters are bidirectional; usually you connect the incoming power to the upper side, and the outgoing power connections to the lower side; but sometimes (often!) your power panel has the power coming from the lower side, and the outgoing connections are at the upper side.

When this "inverted" installation is used, all the currents have to be multiplied by -1 so that the Smartmeter has the correct interpretation of the MAINSCURRENTs.

This PR adds another kWh "InvEastrn" (Inverted Eastron) to the list of kWh meters, that will do exactly the same as the normal Eastron meters, except multiply the measured currents with -1 .